### PR TITLE
Fixed incorrect rotation in WanderingCubes animation

### DIFF
--- a/lib/src/wandering_cubes.dart
+++ b/lib/src/wandering_cubes.dart
@@ -108,20 +108,20 @@ class _SpinKitWanderingCubesState extends State<SpinKitWanderingCubes> with Sing
     Matrix4 tTranslate;
     if (offset == true) {
       tTranslate = Matrix4.identity()
-        ..translate(_translate3.value, 0.0)
-        ..translate(0.0, _translate2.value)
-        ..translate(0.0, _translate4.value)
-        ..translate(_translate1.value, 0.0);
+        ..translate(0.0, -_translate1.value)
+        ..translate(_translate2.value, 0.0)
+        ..translate(0.0, -_translate3.value)
+        ..translate(_translate4.value, 0.0);
     } else {
       tTranslate = Matrix4.identity()
-        ..translate(0.0, _translate3.value)
+        ..translate(0.0, _translate1.value)
         ..translate(-_translate2.value, 0.0)
-        ..translate(-_translate4.value, 0.0)
-        ..translate(0.0, _translate1.value);
+        ..translate(0.0, _translate3.value)
+        ..translate(-_translate4.value, 0.0);
     }
 
     return Positioned(
-      top: 0.0,
+      top: offset == true ? widget.offset : 0.0,
       left: offset == true ? 0.0 : widget.offset,
       child: Transform(
         transform: tTranslate,


### PR DESCRIPTION
The WanderingCubes animation was rotating incorrectly due to a miscalculation in the transformation matrix. Adjusted the rotation logic to align with the intended design, ensuring smooth and accurate animation.

Closes #106